### PR TITLE
Add comprehensive documentation and test suites

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,10 @@
+^.*\.Rproj$
+^\.Rproj\.user$
+^\.git$
+^\.github$
+^\.gitignore$
+^composer\.json$
+^composer\.lock$
+^vendor/
+^docs/examples/
+^README\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata
+.DS_Store
+vendor/
+composer.lock
+*.o
+*.so

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,21 @@
+Package: rmediawiki
+Title: R Interface to MediaWiki Parser
+Version: 0.1.0
+Authors@R: 
+    person("Your", "Name", , "your.email@example.com", role = c("aut", "cre"))
+Description: Provides direct access to MediaWiki's parser functionality from R,
+    allowing conversion of wikitext to HTML without running a MediaWiki server.
+    Includes support for all MediaWiki markup features, bulk processing, and
+    metadata extraction.
+License: GPL (>= 2)
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.3
+Imports: 
+    jsonlite
+SystemRequirements: 
+    PHP (>= 7.4.0),
+    composer
+Suggests: 
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,5 @@
+exportPattern("^[[:alpha:]]+")
+
+export(convert_wikitext)
+export(convert_wikitext_to_html)
+export(convert_wikitext_with_metadata)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,228 @@
+# R MediaWiki Parser
+
+[![R-CMD-check](https://github.com/umatter/r-mediawiki-parser/workflows/R-CMD-check/badge.svg)](https://github.com/umatter/r-mediawiki-parser/actions)
+[![CRAN status](https://www.r-pkg.org/badges/version/rmediawiki)](https://CRAN.R-project.org/package=rmediawiki)
+
+An R package that provides direct access to MediaWiki's parser functionality without requiring a running MediaWiki server. Convert wikitext to HTML, extract metadata, and process multiple files efficiently.
+
+## Features
+
+- **Full MediaWiki Parsing**: Support for all MediaWiki markup features
+  - Basic formatting (bold, italic, etc.)
+  - Links (internal, external, interwiki)
+  - Images and media files
+  - Templates
+  - Tables
+  - Categories
+  - Magic words
+  
+- **Simple R Interface**: Easy-to-use functions for common tasks
+  - `convert_wikitext_to_html()`: Basic wikitext to HTML conversion
+  - `convert_wikitext_with_metadata()`: Get HTML and metadata (links, images, etc.)
+  
+- **Command-line Interface**: Direct access through PHP script
+- **Bulk Processing**: Efficiently handle multiple files
+- **Metadata Extraction**: Access links, images, categories, and more
+
+## Installation
+
+### Prerequisites
+
+1. PHP 7.4 or later
+2. Composer (PHP package manager)
+3. R 3.5.0 or later
+
+### Installing PHP Dependencies
+
+```bash
+# In the package directory
+composer install
+```
+
+### Installing the R Package
+
+```R
+# Install from GitHub
+remotes::install_github("umatter/r-mediawiki-parser")
+```
+
+## Usage
+
+### Basic Usage
+
+```R
+library(rmediawiki)
+
+# Simple conversion
+html <- convert_wikitext_to_html("'''Bold''' and ''italic'' text")
+
+# Get parsing results with metadata
+result <- convert_wikitext_with_metadata("[[Link]] and [[File:image.jpg]]")
+print(result$text)     # HTML content
+print(result$links)    # List of links
+print(result$images)   # List of images
+```
+
+### Bulk Processing
+
+```R
+# Process multiple files
+files <- list.files("wikitext_dir", pattern = "\\.wiki$", full.names = TRUE)
+results <- lapply(files, function(file) {
+    wikitext <- readLines(file, warn = FALSE)
+    convert_wikitext_with_metadata(paste(wikitext, collapse = "\n"))
+})
+```
+
+### Command Line Usage
+
+```bash
+php src/mediawiki_parser.php --wikitext="'''Bold''' text" --format=html
+php src/mediawiki_parser.php --wikitext="[[Link]] text" --format=json
+```
+
+## API Reference
+
+### R Functions
+
+#### convert_wikitext_to_html()
+
+Convert wikitext to HTML.
+
+```R
+convert_wikitext_to_html(wikitext)
+```
+
+- `wikitext`: Character string containing wikitext markup
+- Returns: HTML string
+
+#### convert_wikitext_with_metadata()
+
+Convert wikitext to HTML and extract metadata.
+
+```R
+convert_wikitext_with_metadata(wikitext)
+```
+
+- `wikitext`: Character string containing wikitext markup
+- Returns: List containing:
+  - `text`: HTML content
+  - `links`: Internal and external links
+  - `images`: Image references
+  - `categories`: Category assignments
+  - `templates`: Template usage
+  - `sections`: Document structure
+  - `properties`: Page properties
+
+### PHP Interface
+
+#### StandaloneParser Class
+
+```php
+$parser = new StandaloneParser();
+
+// Parse wikitext to HTML
+$html = $parser->parse($wikitext);
+
+// Parse with metadata
+$result = $parser->parseWithMetadata($wikitext);
+```
+
+## Examples
+
+### Basic Formatting
+
+```R
+wikitext <- "
+== Section Title ==
+'''Bold text''' and ''italic text''
+
+=== Subsection ===
+* List item 1
+* List item 2
+  * Nested item
+
+[[Link to page|Custom text]]
+"
+
+html <- convert_wikitext_to_html(wikitext)
+```
+
+### Tables and Templates
+
+```R
+wikitext <- "
+{|
+|+ Caption
+|-
+! Header 1 !! Header 2
+|-
+| Cell 1 || Cell 2
+|-
+| Cell 3 || Cell 4
+|}
+
+{{Template|param=value}}
+"
+
+result <- convert_wikitext_with_metadata(wikitext)
+```
+
+### Images and Categories
+
+```R
+wikitext <- "
+[[File:example.jpg|thumb|Caption text]]
+
+Some text about the topic.
+
+[[Category:Example]]
+[[Category:Documentation]]
+"
+
+result <- convert_wikitext_with_metadata(wikitext)
+print(result$images)
+print(result$categories)
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+### Development Setup
+
+1. Clone the repository:
+```bash
+git clone https://github.com/umatter/r-mediawiki-parser.git
+cd r-mediawiki-parser
+```
+
+2. Install dependencies:
+```bash
+composer install  # PHP dependencies
+```
+
+3. Run tests:
+```R
+devtools::test()  # R tests
+```
+
+### Running Tests
+
+The package includes comprehensive tests for both R and PHP components:
+
+```R
+# Run R tests
+devtools::test()
+
+# Run PHP tests
+composer test
+```
+
+## License
+
+This project is licensed under the GNU General Public License v2.0 or later - see the [LICENSE](LICENSE) file for details.
+
+## Credits
+
+This package includes code from the [MediaWiki](https://www.mediawiki.org) project.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "mediawiki/standalone-parser",
+    "description": "Standalone version of the MediaWiki parser",
+    "type": "library",
+    "require": {
+        "php": ">=7.4.0",
+        "wikimedia/parsoid": "^0.16.0",
+        "wikimedia/remex-html": "^3.0",
+        "wikimedia/utfnormal": "^3.0",
+        "wikimedia/wrappedstring": "^3.2",
+        "wikimedia/preprocessor": "^0.1.1",
+        "psr/log": "^1.1.4"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
+    "autoload": {
+        "psr-4": {
+            "MediaWiki\\": "lib/includes/",
+            "MediaWiki\\StandaloneParser\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "MediaWiki\\StandaloneParser\\Tests\\": "tests/php/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit tests/php",
+        "test-coverage": "phpunit tests/php --coverage-html coverage"
+    },
+    "license": "GPL-2.0-or-later"
+}

--- a/tests/php/ParserTest.php
+++ b/tests/php/ParserTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ParserTest extends TestCase
+{
+    private $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new StandaloneParser();
+    }
+
+    public function testBasicFormatting()
+    {
+        $html = $this->parser->parse("'''Bold''' and ''italic''");
+        $this->assertStringContainsString('<strong>Bold</strong>', $html);
+        $this->assertStringContainsString('<em>italic</em>', $html);
+    }
+
+    public function testLinks()
+    {
+        $result = $this->parser->parseWithMetadata('[[Main Page|Home]]');
+        $this->assertStringContainsString('<a href="Main_Page">Home</a>', $result['text']);
+        $this->assertArrayHasKey('Main_Page', $result['links']);
+    }
+
+    public function testHeaders()
+    {
+        $wikitext = "== Section 1 ==\nText\n=== Subsection ===\nMore text";
+        $result = $this->parser->parseWithMetadata($wikitext);
+        
+        $this->assertStringContainsString('<h2', $result['text']);
+        $this->assertStringContainsString('<h3', $result['text']);
+        $this->assertGreaterThan(0, count($result['sections']));
+    }
+
+    public function testLists()
+    {
+        $wikitext = "* Item 1\n* Item 2\n** Subitem";
+        $html = $this->parser->parse($wikitext);
+        
+        $this->assertStringContainsString('<ul>', $html);
+        $this->assertStringContainsString('<li>', $html);
+        // Should have nested list
+        $this->assertGreaterThan(
+            strpos($html, '<ul>'),
+            strrpos($html, '<ul>')
+        );
+    }
+
+    public function testTables()
+    {
+        $wikitext = "{|\n|+ Caption\n|-\n! Header 1 !! Header 2\n|-\n| Cell 1 || Cell 2\n|}";
+        $html = $this->parser->parse($wikitext);
+        
+        $this->assertStringContainsString('<table', $html);
+        $this->assertStringContainsString('<caption>Caption</caption>', $html);
+        $this->assertStringContainsString('<th', $html);
+        $this->assertStringContainsString('<td', $html);
+    }
+
+    public function testImages()
+    {
+        $wikitext = '[[File:example.jpg|thumb|Caption text]]';
+        $result = $this->parser->parseWithMetadata($wikitext);
+        
+        $this->assertContains('example.jpg', $result['images']);
+        $this->assertStringContainsString('Caption text', $result['text']);
+    }
+
+    public function testCategories()
+    {
+        $wikitext = "Text\n[[Category:Test]]\n[[Category:Example]]";
+        $result = $this->parser->parseWithMetadata($wikitext);
+        
+        $this->assertArrayHasKey('Test', $result['categories']);
+        $this->assertArrayHasKey('Example', $result['categories']);
+    }
+
+    public function testTemplates()
+    {
+        $wikitext = '{{Template|param=value}}';
+        $result = $this->parser->parseWithMetadata($wikitext);
+        
+        $this->assertArrayHasKey('Template', $result['templates']);
+    }
+
+    public function testErrorHandling()
+    {
+        // Test invalid wikitext
+        $html = $this->parser->parse("'''Unmatched bold");
+        $this->assertIsString($html);
+
+        // Test empty input
+        $html = $this->parser->parse("");
+        $this->assertIsString($html);
+
+        // Test null input
+        $this->expectException(TypeError::class);
+        $this->parser->parse(null);
+    }
+
+    public function testSpecialCharacters()
+    {
+        $html = $this->parser->parse("&amp; &lt; &gt;");
+        $this->assertStringContainsString('&amp;', $html);
+        $this->assertStringContainsString('&lt;', $html);
+        $this->assertStringContainsString('&gt;', $html);
+
+        // Test Unicode
+        $html = $this->parser->parse("Unicode: ñ é ü");
+        $this->assertStringContainsString('ñ', $html);
+        $this->assertStringContainsString('é', $html);
+        $this->assertStringContainsString('ü', $html);
+    }
+
+    public function testLargeContent()
+    {
+        $wikitext = str_repeat("'''Test''' paragraph\n", 1000);
+        $html = $this->parser->parse($wikitext);
+        
+        $this->assertGreaterThan(10000, strlen($html));
+        $this->assertStringContainsString('<strong>Test</strong>', $html);
+    }
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,6 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+library(testthat)
+library(rmediawiki)
+
+test_check("rmediawiki")

--- a/tests/testthat/test-basic-parsing.R
+++ b/tests/testthat/test-basic-parsing.R
@@ -1,0 +1,145 @@
+# Test basic wikitext parsing functionality
+
+test_that("basic formatting works", {
+  # Test bold and italic
+  expect_match(
+    convert_wikitext_to_html("'''Bold'''"),
+    "<strong>Bold</strong>",
+    fixed = TRUE
+  )
+  
+  expect_match(
+    convert_wikitext_to_html("''Italic''"),
+    "<em>Italic</em>",
+    fixed = TRUE
+  )
+  
+  # Test combined formatting
+  expect_match(
+    convert_wikitext_to_html("'''''Bold Italic'''''"),
+    "<strong><em>Bold Italic</em></strong>",
+    fixed = TRUE
+  )
+})
+
+test_that("links are parsed correctly", {
+  result <- convert_wikitext_with_metadata("[[Main Page|Home]]")
+  
+  # Check HTML output
+  expect_match(
+    result$text,
+    '<a href="Main_Page">Home</a>',
+    fixed = TRUE
+  )
+  
+  # Check metadata
+  expect_true("Main_Page" %in% names(result$links))
+})
+
+test_that("headers create proper HTML and TOC", {
+  wikitext <- "
+== Section 1 ==
+Some text
+=== Subsection 1.1 ===
+More text
+== Section 2 ==
+Final text
+"
+  result <- convert_wikitext_with_metadata(wikitext)
+  
+  # Check header HTML
+  expect_match(result$text, "<h2", fixed = TRUE)
+  expect_match(result$text, "<h3", fixed = TRUE)
+  
+  # Check sections metadata
+  expect_true(length(result$sections) >= 3)
+})
+
+test_that("lists are formatted correctly", {
+  wikitext <- "
+* Item 1
+* Item 2
+** Subitem 2.1
+* Item 3
+"
+  html <- convert_wikitext_to_html(wikitext)
+  
+  # Check list structure
+  expect_match(html, "<ul>", fixed = TRUE)
+  expect_match(html, "<li>", fixed = TRUE)
+  expect_true(stringr::str_count(html, "<ul>") >= 2)  # At least one nested list
+})
+
+test_that("tables are parsed properly", {
+  wikitext <- "{|
+|+ Caption
+|-
+! Header 1 !! Header 2
+|-
+| Cell 1 || Cell 2
+|}"
+  
+  html <- convert_wikitext_to_html(wikitext)
+  
+  # Check table structure
+  expect_match(html, "<table", fixed = TRUE)
+  expect_match(html, "<caption>Caption</caption>", fixed = TRUE)
+  expect_match(html, "<th", fixed = TRUE)
+  expect_match(html, "<td", fixed = TRUE)
+})
+
+test_that("images are handled correctly", {
+  result <- convert_wikitext_with_metadata(
+    "[[File:example.jpg|thumb|Caption text]]"
+  )
+  
+  # Check metadata
+  expect_true("example.jpg" %in% result$images)
+  
+  # Check HTML output includes image tag
+  expect_match(result$text, "<img", fixed = TRUE)
+  expect_match(result$text, "Caption text", fixed = TRUE)
+})
+
+test_that("categories are extracted", {
+  result <- convert_wikitext_with_metadata(
+    "Some text\n[[Category:Test]]\n[[Category:Example]]"
+  )
+  
+  # Check categories in metadata
+  expect_true("Test" %in% names(result$categories))
+  expect_true("Example" %in% names(result$categories))
+})
+
+test_that("error handling works", {
+  # Test invalid wikitext (unmatched tags)
+  expect_error(
+    convert_wikitext_to_html("'''Unmatched bold"),
+    NA  # Should not error, but handle gracefully
+  )
+  
+  # Test empty input
+  expect_error(
+    convert_wikitext_to_html(""),
+    NA  # Should handle empty input gracefully
+  )
+  
+  # Test NULL input
+  expect_error(convert_wikitext_to_html(NULL))
+})
+
+test_that("special characters are handled properly", {
+  # Test HTML entities
+  expect_match(
+    convert_wikitext_to_html("&amp; &lt; &gt;"),
+    "&amp; &lt; &gt;",
+    fixed = TRUE
+  )
+  
+  # Test Unicode
+  expect_match(
+    convert_wikitext_to_html("Unicode: ñ é ü"),
+    "Unicode: ñ é ü",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-bulk-processing.R
+++ b/tests/testthat/test-bulk-processing.R
@@ -1,0 +1,51 @@
+# Test bulk processing functionality
+
+test_that("multiple files can be processed", {
+  # Create temporary test files
+  dir.create("wiki_test_files")
+  writeLines("'''File 1''' content", "wiki_test_files/file1.wiki")
+  writeLines("'''File 2''' content", "wiki_test_files/file2.wiki")
+  
+  # Process files
+  files <- list.files("wiki_test_files", pattern = "\\.wiki$", full.names = TRUE)
+  results <- lapply(files, function(file) {
+    wikitext <- readLines(file, warn = FALSE)
+    convert_wikitext_to_html(paste(wikitext, collapse = "\n"))
+  })
+  
+  # Check results
+  expect_equal(length(results), 2)
+  expect_match(results[[1]], "<strong>File 1</strong>", fixed = TRUE)
+  expect_match(results[[2]], "<strong>File 2</strong>", fixed = TRUE)
+  
+  # Clean up
+  unlink("wiki_test_files", recursive = TRUE)
+})
+
+test_that("large files are handled properly", {
+  # Create a large wikitext file
+  large_text <- paste(rep("'''Test''' paragraph\n", 1000), collapse = "")
+  
+  # Process large text
+  result <- convert_wikitext_to_html(large_text)
+  
+  # Check result
+  expect_true(nchar(result) > 10000)
+  expect_match(result, "<strong>Test</strong>", fixed = TRUE)
+})
+
+test_that("concurrent processing works", {
+  # Create test data
+  texts <- replicate(10, "'''Test''' content", simplify = FALSE)
+  
+  # Process concurrently using parallel package
+  library(parallel)
+  cl <- makeCluster(2)
+  results <- parLapply(cl, texts, convert_wikitext_to_html)
+  stopCluster(cl)
+  
+  # Check results
+  expect_equal(length(results), 10)
+  expect_true(all(sapply(results, function(x) 
+    grepl("<strong>Test</strong>", x, fixed = TRUE))))
+})


### PR DESCRIPTION
## Overview
This PR adds comprehensive documentation and test suites to the R MediaWiki Parser package.

## Changes

### Documentation
- Add detailed README.md with:
  - Feature list
  - Installation instructions
  - Usage examples
  - API reference
  - Contributing guidelines
  - License information

### R Test Suite
- Basic parsing tests:
  - Formatting (bold, italic, etc.)
  - Links and images
  - Tables and lists
  - Headers and sections
- Bulk processing tests
- Error handling tests
- Special character handling tests

### PHP Test Suite
- Unit tests for parser functionality
- Error handling tests
- Performance tests for large content
- Special character handling tests

### Package Configuration
- Add proper R package structure
- Configure Composer for PHP dependencies
- Set up test suite configuration
- Add build ignore rules

## Testing
All tests can be run using:
```R
# R tests
devtools::test()
```

```bash
# PHP tests
composer test
```

## Documentation
The README now includes comprehensive documentation for:
- Installation
- Basic usage
- Advanced features
- API reference
- Contributing guidelines

## Next Steps
- Set up GitHub Actions for automated testing
- Add more examples for advanced use cases
- Consider adding performance benchmarks
